### PR TITLE
refactoring for crontabber job integration tests

### DIFF
--- a/socorro/unittest/cron/base.py
+++ b/socorro/unittest/cron/base.py
@@ -7,19 +7,26 @@ import shutil
 import tempfile
 import unittest
 import mock
+import psycopg2
+from psycopg2.extensions import TRANSACTION_STATUS_IDLE
 
 from configman import ConfigurationManager
 from socorro.cron import crontabber
 from socorro.unittest.config.commonconfig import (
-  databaseHost, databaseName, databaseUserName, databasePassword)
+    databaseHost,
+    databaseName,
+    databaseUserName,
+    databasePassword
+)
 
 
 DSN = {
-  "database.database_host": databaseHost.default,
-  "database.database_name": databaseName.default,
-  "database.database_user": databaseUserName.default,
-  "database.database_password": databasePassword.default
+    "database.database_host": databaseHost.default,
+    "database.database_name": databaseName.default,
+    "database.database_user": databaseUserName.default,
+    "database.database_password": databasePassword.default
 }
+
 
 class TestCaseBase(unittest.TestCase):
 
@@ -54,3 +61,42 @@ class TestCaseBase(unittest.TestCase):
             }, DSN, extra_value_source]
         )
         return config_manager, json_file
+
+
+class IntegrationTestCaseBase(TestCaseBase):
+    """Useful class for running integration tests related to crontabber apps
+    since this class takes care of setting up a psycopg connection and it
+    makes sure the `crontabber_state` class is emptied.
+    """
+
+    def setUp(self):
+        super(IntegrationTestCaseBase, self).setUp()
+        assert 'test' in DSN['database.database_name']
+        self.dsn = (
+            'host=%(database.database_host)s '
+            'dbname=%(database.database_name)s '
+            'user=%(database.database_user)s '
+            'password=%(database.database_password)s' % DSN
+        )
+        self.conn = psycopg2.connect(self.dsn)
+
+        cursor = self.conn.cursor()
+        cursor.execute('select count(*) from crontabber_state')
+        if cursor.fetchone()[0] < 1:
+            cursor.execute("""
+            INSERT INTO crontabber_state (state, last_updated)
+            VALUES ('{}', NOW());
+            """)
+        else:
+            cursor.execute("""
+            UPDATE crontabber_state SET state='{}';
+            """)
+        self.conn.commit()
+        assert self.conn.get_transaction_status() == TRANSACTION_STATUS_IDLE
+
+    def tearDown(self):
+        super(IntegrationTestCaseBase, self).tearDown()
+        self.conn.cursor().execute("""
+            UPDATE crontabber_state SET state='{}';
+        """)
+        self.conn.commit()

--- a/socorro/unittest/cron/jobs/test_daily_url.py
+++ b/socorro/unittest/cron/jobs/test_daily_url.py
@@ -4,57 +4,27 @@
 
 import datetime
 import gzip
-import shutil
 import os
 import json
-import unittest
-import tempfile
 from subprocess import PIPE
 import mock
-import psycopg2
-from psycopg2.extensions import TRANSACTION_STATUS_IDLE
 from nose.plugins.attrib import attr
 from socorro.cron import crontabber
-from socorro.unittest.config.commonconfig import (
-  databaseHost, databaseName, databaseUserName, databasePassword)
-from configman import ConfigurationManager
-from ..base import TestCaseBase, DSN
+from ..base import IntegrationTestCaseBase
 
 
 #==============================================================================
 @attr(integration='postgres')  # for nosetests
-class TestFunctionalDailyURL(TestCaseBase):
+class TestFunctionalDailyURL(IntegrationTestCaseBase):
 
     def setUp(self):
         super(TestFunctionalDailyURL, self).setUp()
-        # prep a fake table
-        assert 'test' in DSN['database.database_name']
-        dsn = ('host=%(database.database_host)s '
-               'dbname=%(database.database_name)s '
-               'user=%(database.database_user)s '
-               'password=%(database.database_password)s' % DSN)
-        self.conn = psycopg2.connect(dsn)
-        cursor = self.conn.cursor()
-        cursor.execute('select count(*) from crontabber_state')
-        if cursor.fetchone()[0] < 1:
-            cursor.execute("""
-            INSERT INTO crontabber_state (state, last_updated)
-            VALUES ('{}', NOW());
-            """)
-        else:
-            cursor.execute("""
-            UPDATE crontabber_state SET state='{}';
-            """)
-        self.conn.commit()
-        assert self.conn.get_transaction_status() == TRANSACTION_STATUS_IDLE
-
         self.Popen_patcher = mock.patch('subprocess.Popen')
         self.Popen = self.Popen_patcher.start()
 
     def tearDown(self):
         super(TestFunctionalDailyURL, self).tearDown()
         self.conn.cursor().execute("""
-        UPDATE crontabber_state SET state='{}';
         TRUNCATE TABLE reports CASCADE;
         TRUNCATE TABLE bugs CASCADE;
         TRUNCATE TABLE bug_associations CASCADE;

--- a/socorro/unittest/cron/jobs/test_ftpscraper.py
+++ b/socorro/unittest/cron/jobs/test_ftpscraper.py
@@ -7,12 +7,11 @@ import datetime
 from functools import wraps
 from cStringIO import StringIO
 import mock
-import psycopg2
 from nose.plugins.attrib import attr
 from socorro.cron import crontabber
 from socorro.lib.datetimeutil import utc_now
 from socorro.cron.jobs import ftpscraper
-from ..base import TestCaseBase, DSN
+from ..base import TestCaseBase, IntegrationTestCaseBase
 
 
 def stringioify(func):
@@ -194,18 +193,10 @@ class TestFTPScraper(TestCaseBase):
 
 #==============================================================================
 @attr(integration='postgres')  # for nosetests
-class TestIntegrationFTPScraper(TestCaseBase):
+class TestIntegrationFTPScraper(IntegrationTestCaseBase):
 
     def setUp(self):
         super(TestIntegrationFTPScraper, self).setUp()
-        # prep a fake table
-        assert 'test' in DSN['database.database_name']
-        dsn = ('host=%(database.database_host)s '
-               'dbname=%(database.database_name)s '
-               'user=%(database.database_user)s '
-               'password=%(database.database_password)s' % DSN)
-        self.conn = psycopg2.connect(dsn)
-
         cursor = self.conn.cursor()
 
         # Insert data
@@ -286,7 +277,6 @@ class TestIntegrationFTPScraper(TestCaseBase):
         super(TestIntegrationFTPScraper, self).tearDown()
         cursor = self.conn.cursor()
         cursor.execute("""
-            UPDATE crontabber_state SET state='{}';
             TRUNCATE TABLE releases_raw CASCADE;
             TRUNCATE product_versions CASCADE;
             TRUNCATE products CASCADE;


### PR DESCRIPTION
This patch got bigger than I had hoped but I deem it necessary. 

What happened is that in your test_automatic_emails.py you weren't cleaning up the crontabber_state table. Look at the other `cron/jobs/test_*.py` files that were integration tests. 

I too got strange and weird errors which seemed unrelated. Adding this fix solved all of that. 

So once I realized there are now 4 classes that repeated the same ugly setUp code I refactored them to use one shared integration base test case class. 
