### PR TITLE
DateTimeField with isoformat parsing support

### DIFF
--- a/webapp-django/crashstats/supersearch/form_fields.py
+++ b/webapp-django/crashstats/supersearch/form_fields.py
@@ -114,17 +114,17 @@ class IntegerField(MultiplePrefixedValueField, forms.IntegerField):
 
 class DateTimeField(MultiplePrefixedValueField, forms.DateTimeField):
     def value_to_string(self, value):
-        try:
+        if value:
             return value.isoformat()
-        except AttributeError:  # when value is None
-            return value
 
-    def strptime(self, value, format):
-        try:
-            d = isodate.parse_datetime(value)
-            return d.replace(tzinfo=utc)
-        except ValueError:
-            return super(DateTimeField, self).strptime(value, format)
+    def to_python(self, value):
+        if value:
+            try:
+                return isodate.parse_datetime(value).replace(tzinfo=utc)
+            except ValueError:
+                # let the super method deal with that
+                pass
+        return super(DateTimeField, self).to_python(value)
 
 
 class StringField(MultipleValueField):


### PR DESCRIPTION
@AdrianGaudebert this I think is a better way to get `isodate` in there. 
With this, you do the isodate parsing earlier. Before it starts looping over its various formats. 